### PR TITLE
ロケール設定で既に設定されていればそれを使う。設定が無ければデフォルトとして日本向けにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,9 +113,6 @@ FROM ubuntu:25.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     CLOUDSDK_INSTALL_DIR=/usr/local/google-cloud-sdk \
-    LC_ALL=ja_JP.UTF-8 \
-    LANGUAGE=ja_JP.UTF-8 \
-    LANG=ja_JP.UTF-8 \
     AQUA_VERSION=v2.48.2 \
     AQUA_GLOBAL_CONFIG=/usr/local/etc/aqua.yaml \
     AQUA_ROOT_DIR=/usr/local/aqua \
@@ -220,9 +217,6 @@ RUN apt-get update && \
     curl -fsSL https://install.julialang.org | \
     sh -s -- --yes --path "/usr/local/julia" && \
     /usr/local/julia/bin/juliaup add release && \
-    echo "export LANG=ja_JP.UTF-8" >> /etc/profile.d/locale.sh && \
-    echo "export LANGUAGE=ja_JP.UTF-8" >> /etc/profile.d/locale.sh && \
-    echo "export LC_ALL=ja_JP.UTF-8" >> /etc/profile.d/locale.sh && \
 # Google Cloud SDKのインストール
     curl -fsSL https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=${CLOUDSDK_INSTALL_DIR} && \
 # 独自のビルドオプションを付けたものをCOPYするので

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,22 @@ GROUP_ID="${GID:-1000}"
 USER_NAME="${USER_NAME:-customuser}"
 HOME_DIR="$HOME"
 
+# ロケール設定（デフォルトは ja_JP.UTF-8、環境変数があればそれを使用）
+LOCALE_LANG="${LANG:-ja_JP.UTF-8}"
+LOCALE_LANGUAGE="${LANGUAGE:-ja_JP.UTF-8}"
+LOCALE_LC_ALL="${LC_ALL:-ja_JP.UTF-8}"
+
+# タイムゾーン設定（デフォルトは Asia/Tokyo、環境変数があればそれを使用）
+TIMEZONE="${TZ:-Asia/Tokyo}"
+
+# ロケール環境変数を設定
+export LANG="$LOCALE_LANG"
+export LANGUAGE="$LOCALE_LANGUAGE"
+export LC_ALL="$LOCALE_LC_ALL"
+
+# タイムゾーン環境変数を設定
+export TZ="$TIMEZONE"
+
 # グループの作成
 if ! getent group "${GROUP_ID}" >/dev/null; then
     groupadd -g "${GROUP_ID}" "${USER_NAME}"


### PR DESCRIPTION
# 背景

Dockerfileにロケール設定を直接書いていたが、entrypoint.shで既存の設定があれば、それを使うようにしたい

# やったこと

Dockerfileでの直値をやめentrypoint.shでデフォルト値の設定をした

# やらなかったこと


