### PR TITLE
aqua経由でpinactを追加

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -16,3 +16,4 @@ packages:
   - name: volta-cli/volta@v2.0.2  # nodeパッケージ管理
   - name: x-motemen/ghq@v1.8.0  # ghq: Gitリポジトリ管理
   - name: nodejs/node@v24.2.0
+  - name: suzuki-shunsuke/pinact@v3.3.0


### PR DESCRIPTION
# 背景

go install でインストールしていたpinactをaqua経由でインストールしてデフォルトで使えるようにしたい

# やったこと

aqua.yamlにパッケージ追加

# やらなかったこと


