### PR TITLE
キャッシュの保持を最小にしてdocker-push時のエラーが起きにくくする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           platforms: linux/amd64
           tags: ghcr.io/${{ github.repository_owner }}/cli-tool-docker:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       # mainブランチへのpushの場合のタグ
       - name: Build and Push Docker Image (for main branch)
@@ -81,7 +81,7 @@ jobs:
           platforms: linux/amd64
           tags: ghcr.io/${{ github.repository_owner }}/cli-tool-docker:latest
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       # # Trivyによる脆弱性スキャン（mainのときだけ）
       # - name: Scan image with Trivy


### PR DESCRIPTION
# 背景

```
ERROR: error writing layer blob: GET https://productionresultssa12.blob.core.windows.net/actions-cache/...

403 Server failed to authenticate the request.
Signature not valid in the specified time frame:
  Start [2025-06-19 13:58:20 GMT]
  Expiry [2025-06-19 14:08:25 GMT]
  Current [2025-06-19 14:13:30 GMT]
```
というエラーが出た。

原因: キャッシュ用URL（SASトークン付きBlob URL）の有効期限が切れています。

背景: GitHub Actionsのキャッシュ機構は、キャッシュ保存のために一時的な署名付きURLを生成します。しかし、Docker build に時間がかかりすぎると、有効期限を過ぎてしまい、キャッシュのアップロードが403で失敗します。

```
cache-from: type=gha
cache-to: type=gha,mode=max
```
BuildKit による 「DockerレイヤーキャッシュのGitHub Actionsキャッシュ統合」 ですが、Build が 長時間（5分〜10分以上） かかると、署名付きURLの有効期限（通常10分）を超えてしまい、キャッシュの「書き出し」が失敗します。

# やったこと

mode=max から mode=min に変更

# やらなかったこと
type=gha をやめて、以下のような形で ~/.cache ディレクトリなどを actions/cache によって保存するアプローチもあるかもしれないが、まずminにしてみる

