### PR TITLE
golangのcliツールでmacのunameの処理が違っていたので修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,12 @@ RUN set -euo pipefail && \
     chmod +x /usr/local/bin/ghq && \
     rm ghq.zip && \
 # OSC52を使ってコピーアンドペーストできるコマンドを追加
+    ARCH=$(uname -m) && \
+    case "$ARCH" in \
+      x86_64) ARCH="x86_64" ;; \
+      aarch64) ARCH="arm64" ;; \
+      *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
+    esac && \
     FILENAME="osc_Linux_${ARCH}.tar.gz" && \
     curl -L "https://github.com/theimpostor/osc/releases/download/${OSC_VERSION}/${FILENAME}" \
       -o osc.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,11 +125,10 @@ RUN set -euo pipefail && \
     URL="https://github.com/x-motemen/ghq/releases/download/${GHQ_VERSION}/${FILENAME}" && \
     curl -sSL "$URL" -o ghq.zip && \
     unzip ghq.zip && \
-    mv ghq_linux_amd64/ghq /usr/local/bin/ghq && \
+    mv ghq_linux_${ARCH}/ghq /usr/local/bin/ghq && \
     chmod +x /usr/local/bin/ghq && \
-    rm ghq.zip
+    rm ghq.zip && \
 # OSC52を使ってコピーアンドペーストできるコマンドを追加
-RUN ARCH=$(uname -m) && \
     FILENAME="osc_Linux_${ARCH}.tar.gz" && \
     curl -L "https://github.com/theimpostor/osc/releases/download/${OSC_VERSION}/${FILENAME}" \
       -o osc.tar.gz && \


### PR DESCRIPTION
# 背景
Dockerfile、x86_64では動作するがaarch64(mac)では動作しなかったので修正

# やったこと
golangのcliツールでmacのunameの処理が違っていたので修正

# やらなかったこと


