### PR TITLE
Add age CLI to work image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
       language-pack-ja language-pack-ja-base locales tzdata && \
     locale-gen ja_JP.UTF-8 && \
     apt-get -y --no-install-recommends install \
+      age \
       ansible \
       ansible-lint \
       bat \
@@ -525,7 +526,9 @@ RUN if getent passwd ubuntu >/dev/null; then userdel -r ubuntu; fi && \
     if getent group ubuntu >/dev/null; then groupdel ubuntu; fi
 
 COPY --from=artifacts / /
-RUN test "$(command -v uv)" = /usr/local/bin/uv && \
+RUN command -v age >/dev/null && \
+    command -v age-keygen >/dev/null && \
+    test "$(command -v uv)" = /usr/local/bin/uv && \
     test "$(command -v uvx)" = /usr/local/bin/uvx && \
     test -x /usr/local/bin/uv && \
     test -x /usr/local/bin/uvx && \


### PR DESCRIPTION
## 概要

SOPS age鍵の運用・検証で使う`age`と`age-keygen`をCLI作業用コンテナへ追加します。

## 変更

- Ubuntu 26.04の`age`パッケージをbase stageへ追加
- final stageで`age`と`age-keygen`の存在を検証

## 背景

`homecluster-inventory`のSOPS復号自体は成功していましたが、recipient照合や鍵生成に使う`age-keygen`がコンテナに存在しませんでした。

## Validation

- 元DockerfileをGit blob SHA `328d0af7...`として完全一致確認後に最小差分を適用
- PR差分はDockerfileのみ（+4/-1）
- GitHub Actionsのimage buildで最終確認予定
