### PR TITLE
DRI render node の権限をコンテナ利用者へ引き継ぐ

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ docker version
 docker ps
 ```
 
+# コンテナ内から GPU render node を使う
+
+`/dev/dri/renderD128` がある host では、`shell.bash` がその数値 GID を
+`DRI_RENDER_GID` として渡す。`entrypoint.bash` は対応する group をコンテナ内に
+作成して作業ユーザーへ追加するため、`setpriv --init-groups` 後も render node へ
+アクセスできる。コンテナは `--privileged` で起動するため、追加の `--device` 指定は不要である。
+
+host とコンテナ内で次を確認する。
+
+```bash
+stat -Lc '%n %a %u %g %U %G %F' /dev/dri/renderD128
+id -a
+test -rw /dev/dri/renderD128 && echo 'render node accessible'
+```
+
+`renderD128` がない host では GPU 用の group は追加されない。この変更は WebGPU/Vulkan
+利用の前提となる Unix 権限を整えるだけで、利用するアプリケーションの GPU backend を有効化するものではない。
+
 `shell.bash` は `docker run --rm` で常駐コンテナを起動する。
 このため `cli-tool-docker` コンテナが停止するとコンテナオブジェクトは自動削除され、次回は新しいコンテナを作成する。
 host の `$HOME` は bind mount なので、作業ファイルはコンテナ削除の対象外。

--- a/entrypoint.bash
+++ b/entrypoint.bash
@@ -8,6 +8,7 @@ USER_NAME="${USER_NAME:-${USER:-customuser}}"
 HOME_DIR="$HOME"
 GROUP_NAME="$USER_NAME"
 DOCKER_SOCK_GID="${DOCKER_SOCK_GID:-}"
+DRI_RENDER_GID="${DRI_RENDER_GID:-}"
 
 # ロケール設定（デフォルトは ja_JP.UTF-8、環境変数があればそれを使用）
 LOCALE_LANG="${LANG:-ja_JP.UTF-8}"
@@ -40,6 +41,7 @@ cat <<EOF
   HOME_DIR: $HOME_DIR
   GROUP_NAME: $GROUP_NAME
   DOCKER_SOCK_GID: ${DOCKER_SOCK_GID}
+  DRI_RENDER_GID: ${DRI_RENDER_GID}
   LOCALE_LANG: $LOCALE_LANG
   LOCALE_LANGUAGE: $LOCALE_LANGUAGE
   LOCALE_LC_ALL: $LOCALE_LC_ALL
@@ -124,6 +126,7 @@ if [ "$CAN_MANAGE_ACCOUNTS" -eq 1 ]; then
         fi
 
         add_user_to_gid_group "$DOCKER_SOCK_GID" docker-host
+        add_user_to_gid_group "$DRI_RENDER_GID" render-host
     else
         echo "[entrypoint] WARN: ${USER_NAME} ユーザーが存在しないため、dialout 追加をスキップします" >&2
     fi

--- a/shell.bash
+++ b/shell.bash
@@ -109,6 +109,8 @@ if [ -z "$CONTAINER_ID" ]; then
     VOLUME_OPTS=()
     DOCKER_GROUP_OPTS=()
     DOCKER_SOCK_GID=""
+    DRI_GROUP_OPTS=()
+    DRI_RENDER_GID=""
     if [ -S /var/run/docker.sock ]; then
         VOLUME_OPTS+=(--volume /var/run/docker.sock:/var/run/docker.sock)
         DOCKER_SOCK_GID="$(get_path_gid /var/run/docker.sock)"
@@ -119,6 +121,20 @@ if [ -z "$CONTAINER_ID" ]; then
         fi
     else
         echo "[shell] ⚠️ /var/run/docker.sock が見つかりません。docker は使えないかもしれません。" >&2
+    fi
+
+    # WebGPU/Vulkan などで使う render node は通常 0660 root:<render gid>。
+    # --privileged により device はコンテナから見えるが、作業ユーザーには host 側の
+    # 数値 GID を supplementary group として引き継ぐ必要がある。
+    if [ -c /dev/dri/renderD128 ]; then
+        DRI_RENDER_GID="$(get_path_gid /dev/dri/renderD128)"
+        if [ -n "$DRI_RENDER_GID" ]; then
+            DRI_GROUP_OPTS+=(--group-add "${DRI_RENDER_GID}")
+        else
+            echo "[shell] ⚠️ /dev/dri/renderD128 の GID を取得できませんでした。GPU は権限不足になるかもしれません。" >&2
+        fi
+    else
+        echo "[shell] /dev/dri/renderD128 が見つかりません。GPU render node は引き継ぎません。" >&2
     fi
 
     if [ -S /run/containerd/containerd.sock ]; then
@@ -163,6 +179,7 @@ if [ -z "$CONTAINER_ID" ]; then
   id -g: $(id -g)
   IMAGE_NAME: $IMAGE_NAME
   DOCKER_SOCK_GID: ${DOCKER_SOCK_GID}
+  DRI_RENDER_GID: ${DRI_RENDER_GID}
   INIT_OPT: ${INIT_OPT[*]}
   RM_OPT: ${RM_OPT[*]}
 EOF
@@ -182,10 +199,12 @@ EOF
         --env GID="$(id -g)" \
         --env USER="$(whoami)" \
         --env DOCKER_SOCK_GID="${DOCKER_SOCK_GID}" \
+        --env DRI_RENDER_GID="${DRI_RENDER_GID}" \
         -w "${HOME}" \
         --privileged \
         --group-add 20 \
         "${DOCKER_GROUP_OPTS[@]}" \
+        "${DRI_GROUP_OPTS[@]}" \
         "${INIT_OPT[@]}" \
         "${RM_OPT[@]}" \
         "$IMAGE_NAME:latest"


### PR DESCRIPTION
## 変更内容

- host の `/dev/dri/renderD128` の数値 GID を起動時に取得し、コンテナへ渡すようにしました。
- entrypoint で対応する group を作業ユーザーへ追加し、`setpriv --init-groups` 後も render node へアクセスできるようにしました。
- GPU render node の確認・再作成手順を README に記載しました。

## 背景

`mcp-local-rag` の WebGPU/Vulkan 利用を検証する際、コンテナ内ユーザーが host の render node group を持たず `/dev/dri/renderD128` にアクセスできませんでした。

## 確認

- `bash -n shell.bash`
- `bash -n entrypoint.bash`
- `git diff --check`

ローカル image build は既存の Docker credential helper が GUI D-Bus を要求して base image metadata の取得に失敗したため、GitHub Actions で実行します。